### PR TITLE
Fix mypy no-redef error in cli.py

### DIFF
--- a/src/json_to_schema/cli.py
+++ b/src/json_to_schema/cli.py
@@ -185,8 +185,8 @@ def main() -> None:
         if args.field_description:
             parser.error("--field-description cannot be used with --validate")
 
-        schema = load_schema_json(parser, args.validate)
-        schema_errors = validate_schema_definition(schema)
+        existing_schema = load_schema_json(parser, args.validate)
+        schema_errors = validate_schema_definition(existing_schema)
         if schema_errors:
             print(
                 f"Invalid schema in {args.validate}:",
@@ -197,7 +197,7 @@ def main() -> None:
             raise SystemExit(1)
 
         payload = load_input_json(parser, args.input)
-        validation_errors = validate_against_schema(payload, schema)
+        validation_errors = validate_against_schema(payload, existing_schema)
         if validation_errors:
             print(
                 f"Validation failed: input data does not match schema {args.validate}.",


### PR DESCRIPTION
- Rename `schema` to `existing_schema` in the `--validate` branch of `main()` to fix a mypy `[no-redef]` error caused by the same variable name being assigned again later in the function.

I hit this when running `uv run --all-extras --with=mypy mypy src/ tests/`.
I did that because I want to submit a PR to remove some instances of `Any` types.